### PR TITLE
Adapt to the removal of x11-libs/dbusmenu[qt5]

### DIFF
--- a/packages/lxqt/lxqt-panel/lxqt-panel-0.14.0-r1.exheres-0
+++ b/packages/lxqt/lxqt-panel/lxqt-panel-0.14.0-r1.exheres-0
@@ -21,7 +21,7 @@ DEPENDENCIES="
         lxqt/lxqt-globalkeys
         sys-libs/libstatgrab [[ note = [ cpuload and networkmonitor plugin ] ]]
         sys-libs/libsysstat[>0.1.0] [[ note = [ plugin-sysstat ] ]]
-        x11-libs/dbusmenu-qt[qt5] [[ note = [ plugin-statusnotifier ] ]]
+        x11-libs/dbusmenu-qt[qt5(+)] [[ note = [ plugin-statusnotifier ] ]]
         x11-libs/libX11
         x11-libs/libXext
         x11-libs/libxcb

--- a/packages/lxqt/lxqt-qtplugin/lxqt-qtplugin-0.14.0-r1.exheres-0
+++ b/packages/lxqt/lxqt-qtplugin/lxqt-qtplugin-0.14.0-r1.exheres-0
@@ -11,7 +11,7 @@ MYOPTIONS=""
 DEPENDENCIES="
     build+run:
         lxqt/libqtxdg[>=3.3.0]
-        x11-libs/dbusmenu-qt[qt5]
+        x11-libs/dbusmenu-qt[qt5(+)]
         x11-libs/libfm-qt
         x11-libs/qtbase:5[>=5.7.1]
         x11-libs/qttools:5[>=5.7.1]


### PR DESCRIPTION
The qt5 option is now hard enabled.