### PR TITLE
lxqt-policykit: Adjust to the removal of polkit-qt[qt5]

### DIFF
--- a/packages/lxqt/lxqt-policykit/lxqt-policykit-0.14.0-r1.exheres-0
+++ b/packages/lxqt/lxqt-policykit/lxqt-policykit-0.14.0-r1.exheres-0
@@ -14,7 +14,7 @@ DEPENDENCIES="
     build+run:
         lxqt/liblxqt[~${PV}]
         lxqt/libqtxdg
-        sys-auth/polkit-qt[qt5]
+        sys-auth/polkit-qt[qt5(+)]
         x11-libs/qtbase:5[>=5.7.1]
         x11-libs/qttools:5[>=5.7.1]
 "


### PR DESCRIPTION
It is hard-enabled now.